### PR TITLE
apply multi-stage docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,45 @@
-FROM golang:1.14.6-alpine3.12
+# BASE STAGE
+FROM golang:1.14.6-alpine3.12 as main
 
 ENV EVENTNATIVE_USER=eventnative
 
+RUN addgroup -S $EVENTNATIVE_USER \
+    && adduser -S -G $EVENTNATIVE_USER $EVENTNATIVE_USER \
+    && mkdir -p /home/$EVENTNATIVE_USER/logs/events \
+    && mkdir -p /home/$EVENTNATIVE_USER/app/res \
+    && chown -R $EVENTNATIVE_USER:$EVENTNATIVE_USER /home/$EVENTNATIVE_USER
+
+#######################################
+# BUILD STAGE
+FROM main as builder
+
 # Install dependencies
-RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-RUN apk add git make bash npm shadow@testing
+RUN apk add git make bash npm
 
 # Copy project
 ADD . /go/src/github.com/ksensehq/eventnative
 
-# Create eventnative group & user & dirs
-RUN groupadd -r $EVENTNATIVE_USER \
-    && useradd -r -d /home/$EVENTNATIVE_USER -g $EVENTNATIVE_USER $EVENTNATIVE_USER \
-    && mkdir /home/$EVENTNATIVE_USER \
-    && mkdir -p /home/$EVENTNATIVE_USER/logs/events \
-    && mkdir -p /home/$EVENTNATIVE_USER/app/res \
-    && chown -R $EVENTNATIVE_USER:$EVENTNATIVE_USER /home/$EVENTNATIVE_USER \
-    && chown -R $EVENTNATIVE_USER:$EVENTNATIVE_USER /go/src/github.com/ksensehq/eventnative
+RUN chown -R $EVENTNATIVE_USER:$EVENTNATIVE_USER /go/src/github.com/ksensehq/eventnative
 
 # Build
-USER $EVENTNATIVE_USER
 WORKDIR /go/src/github.com/ksensehq/eventnative
+USER $EVENTNATIVE_USER
 RUN make
 
 # Copy static files
-RUN cp -r /go/src/github.com/ksensehq/eventnative/build/dist/* /home/$EVENTNATIVE_USER/app/
+RUN cp -r ./build/dist/* /home/$EVENTNATIVE_USER/app/
 
-# Delete go files
-USER root
-RUN rm -rf /go/ \
-    && rm -rf /usr/local/go
+#######################################
+# FINAL STAGE
+FROM main as final
 
 USER $EVENTNATIVE_USER
 WORKDIR /home/$EVENTNATIVE_USER/app
 
+# copy static files from build-image
+COPY --from=builder /home/$EVENTNATIVE_USER/app .
+
+VOLUME ["/home/$EVENTNATIVE_USER/app/res", "/home/$EVENTNATIVE_USER/logs/events"]
 EXPOSE 8001
 
-ENTRYPOINT /home/$EVENTNATIVE_USER/app/$EVENTNATIVE_USER -cfg=/home/$EVENTNATIVE_USER/app/res/eventnative.yaml -cr=true
+ENTRYPOINT ["./eventnative", "-cfg=./res/eventnative.yaml", "-cr=true"]


### PR DESCRIPTION
Hi!
After reading your blog at habr.com and experimenting with EventNative I've found that docker image contains unnecessary layers which makes it so huge.
This patch makes image 3-x small compares to origin one.
```
root@kuhwpc:/data0/github.com/iaroslavscript/eventnative# docker images
REPOSITORY                   TAG                 IMAGE ID            CREATED             SIZE
iaroslavscript-eventnative   latest              6468ccd33b3c        21 minutes ago      412MB
ksense/eventnative           latest              65e212d15d3a        3 days ago          1.42GB
golang                       1.14.6-alpine3.12   30df784d6206        3 months ago        370MB
```
As you can see the size of image after the patch is only 412MB which is only 42MB bigger than alpine image itself.